### PR TITLE
Add Delete Confirmation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.confirmations.ConfirmDelete;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
@@ -24,12 +25,18 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
-
     private final Index targetIndex;
+    private boolean isConfirmed = false;
 
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
+
+    // setter method for testing purposes
+    public void setConfirmed(boolean isConfirmed) {
+        this.isConfirmed = isConfirmed;
+    }
+
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -41,6 +48,14 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        // display confirmation dialog - not sure if this is the best place to put it
+        if (!isConfirmed) {
+            ConfirmDelete.showConfirmationDialog(personToDelete);
+        }
+        if (!isConfirmed) {
+            throw new CommandException("You have cancelled the deletion!");
+        }
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }

--- a/src/main/java/seedu/address/logic/confirmations/ConfirmDelete.java
+++ b/src/main/java/seedu/address/logic/confirmations/ConfirmDelete.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.confirmations;
+import java.util.Optional;
+
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import seedu.address.logic.Messages;
+import seedu.address.model.person.Person;
+
+/**
+ * Prompts the user to confirm the deletion of a person
+ */
+public class ConfirmDelete {
+    public static final String MESSAGE_CONFIRM_DELETE = "Are you sure you want to delete Person: %1$s ?";
+
+    /**
+     * Displays a confirmation dialog to prompt the user to confirm the deletion.
+     * @param personToDelete The person the user wants to delete
+     * @return Whether the deletion proceeds or not
+     */
+    public static boolean showConfirmationDialog(Person personToDelete) {
+        Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+        alert.setTitle("Delete Confirmation");
+        alert.setHeaderText(null);
+        alert.setContentText(String.format(MESSAGE_CONFIRM_DELETE, Messages.format(personToDelete)));
+
+        Optional<ButtonType> result = alert.showAndWait();
+        return result.isPresent() && result.get() == ButtonType.OK;
+    }
+
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -95,6 +95,7 @@ public class ModelManager implements Model {
 
     @Override
     public void deletePerson(Person target) {
+        requireNonNull(target);
         addressBook.removePerson(target);
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.person.Person;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
  * {@code DeleteCommand}.
+ * For testing purposes, mock ConfirmDelete to always return true
  */
 public class DeleteCommandTest {
 
@@ -31,7 +32,7 @@ public class DeleteCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-
+        deleteCommand.setConfirmed(true); // bypasses the user confirmation
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
 
@@ -45,7 +46,7 @@ public class DeleteCommandTest {
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-
+        deleteCommand.setConfirmed(true);
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
@@ -55,6 +56,7 @@ public class DeleteCommandTest {
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        deleteCommand.setConfirmed(true);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -75,6 +77,7 @@ public class DeleteCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        deleteCommand.setConfirmed(true);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }


### PR DESCRIPTION
Add a confirmation dialog for the delete command, command will only be executed upon user's confirmation.
This dialog is in the form of a Alert box in which the user selects yes or cancel, to further optimise for CLI could adapt it to prompt user type "y/n" instead, in future iterations

For unit testing, bypass user confirmation by setting isConfirmed to be true

Closes #34 