### PR TITLE
Fix bugs related to help window

### DIFF
--- a/src/main/java/seedu/address/ui/HelpContentManager.java
+++ b/src/main/java/seedu/address/ui/HelpContentManager.java
@@ -38,18 +38,6 @@ public class HelpContentManager {
                  Navigate to the appropriate issue via the panel on the left.
                 """);
 
-        contentMap.put("Quick Start", """
-                Quick start\n
-                 1. Ensure you have Java `17` or above installed in your
-                 Computer. (Visit the Oracle website for Java 17 installation.)\n
-                 2. Download the latest `.jar` file from the GitHub releases
-                 page.\n
-                 3. Copy the `.jar` file to your desired folder and open a
-                 terminal.\n
-                 4. Run the application using `java -jar fart_in_a.jar`.\n
-                 5. Type commands in the command box and press Enter.
-                """);
-
         contentMap.put("Command Format Guidelines", """
                 Command Format Guidelines\n
                  1. Words in UPPER_CASE are parameters to be supplied by the
@@ -201,9 +189,7 @@ public class HelpContentManager {
                 | Unpaid | `unpaid INDEX` | `unpaid 3` |
                 """);
 
-        // Ensure critical content exists
         assert contentMap.get("Introduction") != null : "Introduction content should not be null";
-        assert contentMap.get("Quick Start") != null : "Quick Start content should not be null";
         assert contentMap.get("Command Summary") != null : "Command Summary content should not be null";
     }
 
@@ -223,7 +209,7 @@ public class HelpContentManager {
      */
     public ObservableList<String> getTableOfContents() {
         ObservableList<String> tocList = FXCollections.observableArrayList(
-                "Introduction", "Quick Start", "Command Format Guidelines", "Adding a Contact",
+                "Introduction", "Command Format Guidelines", "Adding a Contact",
                 "Listing All Contacts", "Editing a Contact", "Finding Contacts", "Deleting a Contact",
                 "Clearing All Entries", "Marking a Person as Paid/Unpaid", "Saving and Editing Data",
                 "Exiting the Program", "Command Summary");
@@ -273,6 +259,6 @@ public class HelpContentManager {
 
         assert !commandSummaryData.isEmpty() : "Command summary data should not be empty";
         table.setItems(commandSummaryData);
-        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        table.setColumnResizePolicy(param -> true);
     }
 }

--- a/src/main/java/seedu/address/ui/HelpLogicManager.java
+++ b/src/main/java/seedu/address/ui/HelpLogicManager.java
@@ -1,9 +1,5 @@
 package seedu.address.ui;
 
-import java.awt.Desktop;
-import java.net.URI;
-
-import javafx.scene.control.Hyperlink;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
@@ -55,42 +51,7 @@ public class HelpLogicManager {
         title.setId("helpTitle");
 
         helpContentFlow.getChildren().add(title);
-
-        if (content.contains("Quick start")) {
-            addQuickStartHyperlinks(helpContentFlow); // Handles hyperlinks specific to "Quick Start"
-        } else {
-            processTextWithBackticks(bodyText, helpContentFlow);
-        }
-    }
-
-    /**
-     * Adds hyperlinks for the "Quick Start" section.
-     */
-    public void addQuickStartHyperlinks(TextFlow helpContentFlow) {
-
-        assert helpContentFlow != null : "TextFlow should not be null";
-
-        Text beforeLink1 = new Text("1. Ensure you have Java ");
-        Hyperlink javaLink = new Hyperlink("17");
-        javaLink.setOnAction(e -> openHyperlink("https://www.oracle.com/java/technologies/downloads/#java17"));
-        Text afterLink1 = new Text(" or above installed in your Computer. (Visit the ");
-
-        Hyperlink oracleLink = new Hyperlink("Oracle website");
-        oracleLink.setOnAction(e -> openHyperlink("https://www.oracle.com/java/technologies/downloads/#java17"));
-        Text afterOracleLink = new Text(" for Java 17 installation.)");
-
-        Text beforeLink2 = new Text("\n\n2. Download the latest ");
-        Hyperlink jarLink = new Hyperlink(".jar file");
-        jarLink.setOnAction(e -> openHyperlink("https://github.com/AY2425S1-CS2103T-F14b-4/tp/releases/tag/v1.0"));
-
-        Text instructions = new Text("\n\n3. Copy the `.jar` file to your desired folder and open a terminal."
-                + "\n\n4. Run the application using `java -jar fart_in_a.jar`."
-                + "\n\n5. Type commands in the command box and press Enter.");
-
-        helpContentFlow.getChildren().addAll(
-                beforeLink1, javaLink, afterLink1, oracleLink, afterOracleLink,
-                beforeLink2, jarLink, instructions
-        );
+        processTextWithBackticks(bodyText, helpContentFlow);
     }
 
     /**
@@ -114,24 +75,6 @@ public class HelpLogicManager {
             }
             helpContentFlow.getChildren().add(t);
             isCode = !isCode;
-        }
-    }
-
-    /**
-     * Opens a hyperlink in the system's default browser.
-     */
-    public void openHyperlink(String url) {
-
-        assert url != null && !url.isEmpty() : "URL should not be null or empty";
-
-        try {
-            if (Desktop.isDesktopSupported()) {
-                Desktop.getDesktop().browse(new URI(url));
-            } else {
-                System.out.println("Platform does not support desktop browsing.");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 }

--- a/src/test/java/seedu/address/ui/HelpContentManagerTest.java
+++ b/src/test/java/seedu/address/ui/HelpContentManagerTest.java
@@ -22,22 +22,16 @@ public class HelpContentManagerTest {
     public void initializeContents_contentMapInitialized() {
         // Check that the contentMap is initialized and contains the expected keys
         assertNotNull(helpContentManager.getContent("Introduction"));
-        assertNotNull(helpContentManager.getContent("Quick Start"));
         assertNotNull(helpContentManager.getContent("Command Summary"));
 
         // Verify that all expected keys are present
-        assertEquals(13, helpContentManager.getTableOfContents().size(),
-                "Table of Contents should contain 13 entries");
+        assertEquals(12, helpContentManager.getTableOfContents().size(),
+                "Table of Contents should contain 12 entries");
     }
 
     @Test
     public void getContent_validKey_returnsCorrectContent() {
         // Check if valid keys return the correct content
-        String quickStartContent = helpContentManager.getContent("Quick Start");
-        assertNotNull(quickStartContent, "Content for 'Quick Start' should not be null");
-        assertEquals(true, quickStartContent.contains("Ensure you have Java `17`"),
-                "Quick Start content mismatch");
-
         String introductionContent = helpContentManager.getContent("Introduction");
         assertNotNull(introductionContent, "Content for 'Introduction' should not be null");
         assertEquals(true, introductionContent.contains("Financial Assurance Revolutionary Telemarketer"),
@@ -56,23 +50,24 @@ public class HelpContentManagerTest {
         // Check that the Table of Contents is initialized and contains the correct items
         ObservableList<String> tableOfContents = helpContentManager.getTableOfContents();
         assertNotNull(tableOfContents, "Table of Contents should not be null");
-        assertEquals(13, tableOfContents.size(), "Table of Contents should contain 13 entries");
 
         // Check if specific items exist in the Table of Contents
         assertEquals("Introduction", tableOfContents.get(0),
                 "First item in the TOC should be 'Introduction'");
-        assertEquals("Quick Start", tableOfContents.get(1),
-                "Second item in the TOC should be 'Quick Start'");
     }
 
     @Test
-    public void contentMap_sizeAndKeys() {
-        // Ensure the content map has the expected number of entries
-        assertEquals(13, helpContentManager.getTableOfContents().size(), "Content map should contain 13 sections");
+    public void tableOfContents_sizeIsCorrect() {
+        // Test to verify the Table of Contents size only once
+        ObservableList<String> tableOfContents = helpContentManager.getTableOfContents();
+        assertEquals(12, tableOfContents.size(), "Table of Contents should contain 12 entries");
+    }
 
+    @Test
+    public void contentMap_containsExpectedKeys() {
         // Verify that all expected keys are present
         String[] expectedKeys = {
-            "Introduction", "Quick Start", "Command Format Guidelines", "Adding a Contact",
+            "Introduction", "Command Format Guidelines", "Adding a Contact",
             "Listing All Contacts", "Editing a Contact", "Finding Contacts", "Deleting a Contact",
             "Clearing All Entries", "Marking a Person as Paid/Unpaid", "Saving and Editing Data",
             "Exiting the Program", "Command Summary"


### PR DESCRIPTION
Closes #98, #119

Removed Quick Start section in the Help Window, reason being low relevance as users will already have downloaded and opened FART before being able to access this Help Window.