### PR TITLE
Revert changes 

### DIFF
--- a/src/main/java/seedu/address/logic/parser/PaidCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PaidCommandParser.java
@@ -2,13 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FREQUENCY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.time.LocalDate;
 
@@ -32,9 +26,7 @@ public class PaidCommandParser implements Parser<PaidCommand> {
     @Override
     public PaidCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_FREQUENCY, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FREQUENCY);
 
         Index index;
         try {
@@ -43,15 +35,8 @@ public class PaidCommandParser implements Parser<PaidCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PaidCommand.MESSAGE_USAGE), pe);
         }
 
-        if (!argMultimap.getValue(PREFIX_FREQUENCY).isPresent() || argMultimap.getValue(PREFIX_FREQUENCY).isEmpty()) {
+        if (!argMultimap.getValue(PREFIX_FREQUENCY).isPresent()) {
             throw new ParseException(PaidCommand.MESSAGE_NO_FREQUENCY);
-        }
-
-
-        if (argMultimap.getValue(PREFIX_NAME).isPresent() || argMultimap.getValue(PREFIX_PHONE).isPresent()
-                || argMultimap.getValue(PREFIX_EMAIL).isPresent() || argMultimap.getValue(PREFIX_ADDRESS).isPresent()
-                || argMultimap.getValue(PREFIX_BIRTHDAY).isPresent() || argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            throw new ParseException("Other prefixes are not allowed for Paid Command");
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_FREQUENCY);

--- a/src/main/java/seedu/address/model/person/Frequency.java
+++ b/src/main/java/seedu/address/model/person/Frequency.java
@@ -17,7 +17,7 @@ public class Frequency {
     }
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Frequency can only be 1, 3, 6 or 12 months and cannot be blank";
+            "Frequency can only be 1, 3, 6 or 12 months";
 
     public final String value;
     public final Months[] months;

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -26,11 +27,6 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", "The person index provided is invalid");
-    }
-
-    @Test
-    public void parse_noIndex_throwsParseException() {
-        assertParseFailure(parser, "", "The person index provided is invalid");
+        assertParseFailure(parser, "a", MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/PaidCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PaidCommandParserTest.java
@@ -32,9 +32,4 @@ public class PaidCommandParserTest {
     public void parse_missingFrequency_throwsParseException() {
         assertParseFailure(parser, "1", PaidCommand.MESSAGE_NO_FREQUENCY);
     }
-
-    @Test
-    public void parse_includeOtherPrefixes() {
-        assertParseFailure(parser, "1 f/3 n/John", "Other prefixes are not allowed for Paid Command");
-    }
 }


### PR DESCRIPTION
Reverting changes as some changes violated feature freeze with #234 and #231. Specifically the additional wrong input checks in PaidCommandParser and the extension to the error message in Frequency. Also removed the additional tests for the changes after feature freeze.


<img width="926" alt="Screenshot 2024-11-12 at 1 32 09 AM" src="https://github.com/user-attachments/assets/b5eb3d09-87c5-4cc4-bc6a-158003223ce0">

<img width="802" alt="Screenshot 2024-11-12 at 1 33 30 AM" src="https://github.com/user-attachments/assets/9448d48b-8bab-4931-a1f8-041f6c0ab579">


Removed tests in DeleteParserTest and reverted to original as well

<img width="862" alt="Screenshot 2024-11-12 at 1 34 42 AM" src="https://github.com/user-attachments/assets/dc2aed1e-41ec-41ec-a55c-f385738a3f24">

